### PR TITLE
fix kumano platform name for gcc builds

### DIFF
--- a/build-kernels-gcc.sh
+++ b/build-kernels-gcc.sh
@@ -28,7 +28,7 @@ GANGES="kirin mermaid"
 TAMA="akari apollo akatsuki"
 KUMANO="griffin"
 
-PLATFORMS="loire tone yoshino nile ganges tama griffin"
+PLATFORMS="loire tone yoshino nile ganges tama kumano"
 
 cd $KERNEL_TOP/kernel
 


### PR DESCRIPTION
Change the device name to the platform
name in the list of platforms.