### PR TITLE
[aosp/LA.UM.7.1.r1] Build mkdtimg correctly in Android 11

### DIFF
--- a/c
+++ b/c
@@ -22,7 +22,7 @@ if [ ! -f $MKDTIMG ]; then
     echo "mkdtimg: File not found!"
     echo "Building mkdtimg"
     export ALLOW_MISSING_DEPENDENCIES=true
-    make mkdtimg
+    $ANDROID_ROOT/build/soong/soong_ui.bash --make-mode mkdtimg
 fi
 
 YOSHINO="lilac maple poplar"


### PR DESCRIPTION
In Android 11 calling `make` directly is no longer supported, so if
we don't find `mkdtimg `and try to build it using `make`, it will fail:

```
mkdtimg: File not found!
Building mkdtimg
build/make/core/main.mk:2: Calling make directly is no longer supported.
build/make/core/main.mk:3: Either use 'envsetup.sh; m' or 'build/soong/soong_ui.bash --make-mode'
build/make/core/main.mk:4: *** done.  Stop.
```